### PR TITLE
Add dataset training loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ A comprehensive AI-powered hand sign recognition system that uses your webcam to
    python train_model.py
    ```
 
+   You can also train directly from a dataset by providing its path:
+   ```bash
+   python train_model.py --dataset path/to/dataset
+   ```
+   The dataset directory should contain one subfolder per sign label with
+   either image files or JSON landmark files.
+
+   Example structure:
+   ```
+   dataset/
+     A/  # samples for sign "A"
+       image1.jpg
+       sample2.json
+     B/
+       ...
+   ```
+
 2. **Collect training data**
    - Use command: `collect <sign_name>`
    - Hold your hand in the desired position


### PR DESCRIPTION
## Summary
- add TensorFlow-based dataset training option in `train_model.py`
- teach `train_model.py` to load images or landmark JSON files and train a model
- document dataset structure and new CLI argument in README

## Testing
- `python -m py_compile train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_688914eaad108326b61606e2064358ed